### PR TITLE
Bump actions/checkout dependency to latest major

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run action (no inputs expected)
         uses: ./
         id: print_inputs
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run action (inputs expected)
         uses: ./
         id: print_inputs
@@ -63,7 +63,7 @@ jobs:
   test-env-vars:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run action (with env vars)
         uses: ./
         id: print_inputs_and_env


### PR DESCRIPTION
Thanks for creating this action, it's just what I was looking for ❤️ 

I noticed this dependency could use a bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of a GitHub Actions dependency to improve workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->